### PR TITLE
Save image with unit8list

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Add the following key to your _AndroidManifest_ file, located in
 ```dart
 //Save Image
 await Gal.putImage('$filePath');
+await Gal.putImageBytes('$uint8List');
 
 //Save Video
 await Gal.putVideo('$filePath');

--- a/android/src/main/java/studio/midoridesign/gal/GalPlugin.java
+++ b/android/src/main/java/studio/midoridesign/gal/GalPlugin.java
@@ -58,16 +58,14 @@ public class GalPlugin
             case "putImage":
             case "putVideoBytes":
             case "putImageBytes": {
-                Uri contentUri = call.method.startsWith("putVideo") ? MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+                Uri uri = call.method.startsWith("putVideo") ? MediaStore.Video.Media.EXTERNAL_CONTENT_URI
                         : MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
                 CompletableFuture.runAsync(() -> {
                     try {
                         if (call.method.contains("Bytes")) {
-                            byte[] bytes = call.argument("bytes");
-                            putMediaBytes(pluginBinding.getApplicationContext(), bytes, contentUri);
+                            putMediaBytes(pluginBinding.getApplicationContext(), (byte[]) call.argument("bytes"), uri);
                         } else {
-                            String path = call.argument("path");
-                            putMedia(pluginBinding.getApplicationContext(), path, contentUri);
+                            putMedia(pluginBinding.getApplicationContext(), (String) call.argument("path"), uri);
                         }
                         new Handler(Looper.getMainLooper()).post(() -> result.success(null));
                     } catch (Exception e) {

--- a/android/src/main/java/studio/midoridesign/gal/GalPlugin.java
+++ b/android/src/main/java/studio/midoridesign/gal/GalPlugin.java
@@ -32,6 +32,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.ByteArrayInputStream;
 import java.util.concurrent.CompletableFuture;
 
 public class GalPlugin
@@ -54,14 +55,20 @@ public class GalPlugin
     public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
         switch (call.method) {
             case "putVideo":
-            case "putImage": {
-                String path = call.argument("path");
-                Uri contentUri = call.method.equals("putVideo") ? MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+            case "putImage":
+            case "putVideoBytes":
+            case "putImageBytes": {
+                Uri contentUri = call.method.startsWith("putVideo") ? MediaStore.Video.Media.EXTERNAL_CONTENT_URI
                         : MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-
                 CompletableFuture.runAsync(() -> {
                     try {
-                        putMedia(pluginBinding.getApplicationContext(), path, contentUri);
+                        if (call.method.contains("Bytes")) {
+                            byte[] bytes = call.argument("bytes");
+                            putMediaBytes(pluginBinding.getApplicationContext(), bytes, contentUri);
+                        } else {
+                            String path = call.argument("path");
+                            putMedia(pluginBinding.getApplicationContext(), path, contentUri);
+                        }
                         new Handler(Looper.getMainLooper()).post(() -> result.success(null));
                     } catch (Exception e) {
                         handleError(e, result);
@@ -91,17 +98,27 @@ public class GalPlugin
 
     private void putMedia(Context context, String path, Uri contentUri)
             throws IOException, SecurityException, FileNotFoundException {
+        File file = new File(path);
+        try (InputStream in = new FileInputStream(file)) {
+            writeContent(context, in, contentUri);
+        }
+    }
+
+    private void putMediaBytes(Context context, byte[] bytes, Uri contentUri)
+            throws IOException, SecurityException {
+        try (InputStream in = new ByteArrayInputStream(bytes)) {
+            writeContent(context, in, contentUri);
+        }
+    }
+
+    private void writeContent(Context context, InputStream in, Uri contentUri)
+            throws IOException, SecurityException {
         ContentResolver resolver = context.getContentResolver();
         ContentValues values = new ContentValues();
-        File file = new File(path);
-
-        values.put(MediaStore.MediaColumns.DISPLAY_NAME, file.getName());
         values.put(MediaStore.MediaColumns.DATE_ADDED, System.currentTimeMillis());
-
         Uri mediaUri = resolver.insert(contentUri, values);
 
-        try (OutputStream out = resolver.openOutputStream(mediaUri);
-                InputStream in = new FileInputStream(file)) {
+        try (OutputStream out = resolver.openOutputStream(mediaUri)) {
             byte[] buffer = new byte[8192];
             int bytesRead;
             while ((bytesRead = in.read(buffer)) != -1) {
@@ -129,7 +146,7 @@ public class GalPlugin
         return hasAccess == PackageManager.PERMISSION_GRANTED;
     }
 
-    // If permissions have already been granted by the user, 
+    // If permissions have already been granted by the user,
     // returns true immediately without displaying the dialog.
     private CompletableFuture<Boolean> requestAccess() {
         accessRequestResult = new CompletableFuture<>();

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
-
+    <uses-permission android:name="android.permission.INTERNET"/>
+    
     <!-- Gal: If supports API <29 add this key :Gal-->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <!-- Gal: If supports API <29 add this key :Gal-->

--- a/example/integration_test/integration_test.dart
+++ b/example/integration_test/integration_test.dart
@@ -37,6 +37,14 @@ void main() {
             expect(tester.takeException(), isNull);
           });
 
+          testWidgets('putImageBytes()', (tester) async {
+            app.main();
+            await tester.pumpAndSettle();
+            final button = find.byIcon(Icons.image_rounded);
+            await tester.tap(button);
+            expect(tester.takeException(), isNull);
+          });
+
           testWidgets('open()', (tester) async {
             app.main();
             await tester.pumpAndSettle();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -91,6 +91,19 @@ class App extends StatelessWidget {
                   ),
                   _Button(
                     onPressed: () async {
+                      final res = await Dio().get(
+                          'https://github.com/natsuk4ze/gal/raw/main/example/assets/done.mp4',
+                          options: Options(responseType: ResponseType.bytes));
+                      await Gal.putVideoBytes(Uint8List.fromList(res.data));
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                      }
+                    },
+                    label: 'Save Video from bytes',
+                    icon: Icons.video_file_rounded,
+                  ),
+                  _Button(
+                    onPressed: () async {
                       final path = '${Directory.systemTemp.path}/done.mp4';
                       await Dio().download(
                         'https://github.com/natsuk4ze/gal/raw/main/example/assets/done.mp4',
@@ -114,6 +127,19 @@ class App extends StatelessWidget {
                     },
                     label: 'Save Image from local',
                     icon: Icons.image,
+                  ),
+                  _Button(
+                    onPressed: () async {
+                      final res = await Dio().get(
+                          'https://github.com/natsuk4ze/gal/raw/main/example/assets/done.jpg',
+                          options: Options(responseType: ResponseType.bytes));
+                      await Gal.putImageBytes(Uint8List.fromList(res.data));
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                      }
+                    },
+                    label: 'Save Image from bytes',
+                    icon: Icons.image_rounded,
                   ),
                   _Button(
                     onPressed: () async {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -91,19 +91,6 @@ class App extends StatelessWidget {
                   ),
                   _Button(
                     onPressed: () async {
-                      final res = await Dio().get(
-                          'https://github.com/natsuk4ze/gal/raw/main/example/assets/done.mp4',
-                          options: Options(responseType: ResponseType.bytes));
-                      await Gal.putVideoBytes(Uint8List.fromList(res.data));
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                      }
-                    },
-                    label: 'Save Video from bytes',
-                    icon: Icons.video_file_rounded,
-                  ),
-                  _Button(
-                    onPressed: () async {
                       final path = '${Directory.systemTemp.path}/done.mp4';
                       await Dio().download(
                         'https://github.com/natsuk4ze/gal/raw/main/example/assets/done.mp4',

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: b99b1d56dc0d5dece70957023af002dbd49614b4a1bf86d3a254af3fe781bdf2
+      sha256: a9d76e72985d7087eb7c5e7903224ae52b337131518d127c554b9405936752b8
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0+1"
+    version: "5.2.1+1"
   fake_async:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dio: ^5.2.0+1
+  dio: ^5.2.1+1
   gal:
     path: ../
 

--- a/ios/Classes/GalPlugin.swift
+++ b/ios/Classes/GalPlugin.swift
@@ -11,11 +11,22 @@ public class GalPlugin: NSObject, FlutterPlugin {
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
-    case "putImage", "putVideo":
+    case "putVideo", "putImage":
       let args = call.arguments as! [String: String]
       self.putMedia(
         path: args["path"]!,
         isImage: call.method == "putImage"
+      ) { _, error in
+        if let error = error as NSError? {
+          result(self.handleError(error: error))
+        } else {
+          result(nil)
+        }
+      }
+    case "putImageBytes":
+      let args = call.arguments as! [String: FlutterStandardTypedData]
+      self.putImageBytes(
+        bytes: args["bytes"]!.data
       ) { _, error in
         if let error = error as NSError? {
           result(self.handleError(error: error))
@@ -48,6 +59,15 @@ public class GalPlugin: NSObject, FlutterPlugin {
             atFileURL: URL(fileURLWithPath: path))
       },
       completionHandler: completion)
+  }
+
+  private func putImageBytes(
+    bytes: Data, completion: @escaping (Bool, Error?) -> Void
+  ) {
+    PHPhotoLibrary.shared().performChanges(
+      {
+        PHAssetChangeRequest.creationRequestForAsset(from: UIImage(data: bytes)!)
+      }, completionHandler: completion)
   }
 
   private func open(completion: @escaping () -> Void) {

--- a/lib/src/gal.dart
+++ b/lib/src/gal.dart
@@ -21,6 +21,9 @@ final class Gal {
   static Future<void> putVideo(String path) async =>
       _voidOrThrow(() async => GalPlatform.instance.putVideo(path));
 
+  static Future<void> putVideoBytes(Uint8List bytes) async =>
+      _voidOrThrow(() async => GalPlatform.instance.putVideoBytes(bytes));
+
   /// Save image to standard gallery app
   /// [path] is local path.
   /// When this function was called was the first access
@@ -31,6 +34,9 @@ final class Gal {
   /// before calling this function.
   static Future<void> putImage(String path) async =>
       _voidOrThrow(() async => GalPlatform.instance.putImage(path));
+
+  static Future<void> putImageBytes(Uint8List bytes) async =>
+      _voidOrThrow(() async => GalPlatform.instance.putImageBytes(bytes));
 
   /// Open OS standard gallery app.
   /// Open "iOS Photos" when iOS, "Google Photos" or something when Android.

--- a/lib/src/gal.dart
+++ b/lib/src/gal.dart
@@ -21,9 +21,6 @@ final class Gal {
   static Future<void> putVideo(String path) async =>
       _voidOrThrow(() async => GalPlatform.instance.putVideo(path));
 
-  static Future<void> putVideoBytes(Uint8List bytes) async =>
-      _voidOrThrow(() async => GalPlatform.instance.putVideoBytes(bytes));
-
   /// Save image to standard gallery app
   /// [path] is local path.
   /// When this function was called was the first access

--- a/lib/src/gal.dart
+++ b/lib/src/gal.dart
@@ -3,35 +3,31 @@ import 'package:gal/src/gal_exception.dart';
 
 import 'gal_platform_interface.dart';
 
-/// Plugin App Facing
 /// For detailed please see
-/// https://github.com/natsuk4ze/gal/ or
 /// https://github.com/natsuk4ze/gal/wiki
+/// these functions are first called,
+/// [putImage],[putVideo],[putImageBytes],a native dialog is 
+/// called asking the use for permission. If the user chooses to deny,
+/// [GalException] of [GalExceptionType.accessDenied] will be throwed.
+/// You should either do error handling or call [requestAccess] once
+/// before calling these function.
 final class Gal {
   Gal._();
 
   /// Save video to standard gallery app
   /// [path] is local path.
-  /// When this function was called was the first access
-  /// to the gallery app, a native dialog is called asking the user
-  /// for permission. If the user chooses to deny,
-  /// [GalException] of [GalExceptionType.accessDenied] will be throwed.
-  /// You should either do error handling or call [requestAccess] once
-  /// before calling this function.
   static Future<void> putVideo(String path) async =>
       _voidOrThrow(() async => GalPlatform.instance.putVideo(path));
 
   /// Save image to standard gallery app
   /// [path] is local path.
-  /// When this function was called was the first access
-  /// to the gallery app, a native dialog is called asking the user
-  /// for permission. If the user chooses to deny,
-  /// [GalException] of [GalExceptionType.accessDenied] will be throwed.
-  /// You should either do error handling or call [requestAccess] once
-  /// before calling this function.
   static Future<void> putImage(String path) async =>
       _voidOrThrow(() async => GalPlatform.instance.putImage(path));
 
+  /// Save image to standard gallery app
+  /// [Uint8List] version of [putImage]
+  /// It does not require temporary files and saves directly from memory,
+  /// making it fast.
   static Future<void> putImageBytes(Uint8List bytes) async =>
       _voidOrThrow(() async => GalPlatform.instance.putImageBytes(bytes));
 

--- a/lib/src/gal_method_channel.dart
+++ b/lib/src/gal_method_channel.dart
@@ -8,15 +8,21 @@ final class MethodChannelGal extends GalPlatform {
   @visibleForTesting
   final methodChannel = const MethodChannel('gal');
 
-  /// argument is Map.
   @override
   Future<void> putVideo(String path) async =>
       methodChannel.invokeMethod<void>('putVideo', {'path': path});
 
-  /// argument is Map.
+  @override
+  Future<void> putVideoBytes(Uint8List bytes) async =>
+      methodChannel.invokeMethod<void>('putVideoBytes', {'bytes': bytes});
+
   @override
   Future<void> putImage(String path) async =>
       methodChannel.invokeMethod<void>('putImage', {'path': path});
+
+  @override
+  Future<void> putImageBytes(Uint8List bytes) async =>
+      methodChannel.invokeMethod<void>('putImageBytes', {'bytes': bytes});
 
   @override
   Future<void> open() async => methodChannel.invokeMethod<void>('open');
@@ -26,6 +32,7 @@ final class MethodChannelGal extends GalPlatform {
     final hasAccess = await methodChannel.invokeMethod<bool>('hasAccess');
     return hasAccess ?? false;
   }
+
   @override
   Future<bool> requestAccess() async {
     final granted = await methodChannel.invokeMethod<bool>('requestAccess');

--- a/lib/src/gal_method_channel.dart
+++ b/lib/src/gal_method_channel.dart
@@ -13,10 +13,6 @@ final class MethodChannelGal extends GalPlatform {
       methodChannel.invokeMethod<void>('putVideo', {'path': path});
 
   @override
-  Future<void> putVideoBytes(Uint8List bytes) async =>
-      methodChannel.invokeMethod<void>('putVideoBytes', {'bytes': bytes});
-
-  @override
   Future<void> putImage(String path) async =>
       methodChannel.invokeMethod<void>('putImage', {'path': path});
 

--- a/lib/src/gal_platform_interface.dart
+++ b/lib/src/gal_platform_interface.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'gal_method_channel.dart';
@@ -23,6 +25,16 @@ abstract class GalPlatform extends PlatformInterface {
   /// define [putImage].
   Future<void> putImage(String path) =>
       throw UnimplementedError('putImage() has not been implemented.');
+
+  /// throw [UnimplementedError] when Plugin [MethodChannelGal] did not
+  /// define [putImageBytes].
+  Future<void> putImageBytes(Uint8List bytes) =>
+      throw UnimplementedError('putImageBytes() has not been implemented.');
+
+  /// throw [UnimplementedError] when Plugin [MethodChannelGal] did not
+  /// define [putVideoBytes].
+  Future<void> putVideoBytes(Uint8List bytes) =>
+      throw UnimplementedError('putVideoBytes() has not been implemented.');
 
   /// throw [UnimplementedError] when Plugin [MethodChannelGal] did not
   /// define [open].

--- a/lib/src/gal_platform_interface.dart
+++ b/lib/src/gal_platform_interface.dart
@@ -32,11 +32,6 @@ abstract class GalPlatform extends PlatformInterface {
       throw UnimplementedError('putImageBytes() has not been implemented.');
 
   /// throw [UnimplementedError] when Plugin [MethodChannelGal] did not
-  /// define [putVideoBytes].
-  Future<void> putVideoBytes(Uint8List bytes) =>
-      throw UnimplementedError('putVideoBytes() has not been implemented.');
-
-  /// throw [UnimplementedError] when Plugin [MethodChannelGal] did not
   /// define [open].
   Future<void> open() =>
       throw UnimplementedError('open() has not been implemented.');


### PR DESCRIPTION
## Overview
Ability to save images from Uint8List.
No need to prepare a temporary file, and works fast.

I removed `putVideoBytes()` for several reasons.

- I can't find a use case for saving videos from byte data.
- Video files are often large and not recommended to be stored in memory.
- Swift does not support saving videos directly from byte data, it needs to be saved temporarily.
- File conversion causes unexpected errors, such as video codec issues.

## Related Issues (Optional)

- Close #20 
