### PR TITLE
Improved error handling in lower iOS versions

### DIFF
--- a/ios/Classes/GalPlugin.swift
+++ b/ios/Classes/GalPlugin.swift
@@ -101,22 +101,54 @@ public class GalPlugin: NSObject, FlutterPlugin {
   private func handleError(error: NSError) -> FlutterError {
     let message = error.localizedDescription
     let details = Thread.callStackSymbols
-    if #available(iOS 15, *) {
-      switch error.code {
-      case PHPhotosError.accessRestricted.rawValue, PHPhotosError.accessUserDenied.rawValue:
-        return FlutterError(code: "ACCESS_DENIED", message: message, details: details)
-      case PHPhotosError.identifierNotFound.rawValue,
-        PHPhotosError.multipleIdentifiersFound.rawValue,
-        PHPhotosError.requestNotSupportedForAsset.rawValue,
-        3302:
-        return FlutterError(code: "NOT_SUPPORTED_FORMAT", message: message, details: details)
-      case PHPhotosError.notEnoughSpace.rawValue:
-        return FlutterError(code: "NOT_ENOUGH_SPACE", message: message, details: details)
-      default:
-        return FlutterError(code: "UNEXPECTED", message: message, details: details)
-      }
-    } else {
-      return FlutterError(code: "NOT_HANDLE", message: message, details: details)
+    switch error.code {
+    case PHErrorCode.accessRestricted.rawValue, PHErrorCode.accessUserDenied.rawValue:
+      return FlutterError(code: "ACCESS_DENIED", message: message, details: details)
+
+    case PHErrorCode.identifierNotFound.rawValue,
+      PHErrorCode.multipleIdentifiersFound.rawValue,
+      PHErrorCode.requestNotSupportedForAsset.rawValue,
+      PHErrorCode.videoConversionFailed.rawValue,
+      PHErrorCode.unsupportedVideoCodecs.rawValue:
+      return FlutterError(code: "NOT_SUPPORTED_FORMAT", message: message, details: details)
+
+    case PHErrorCode.notEnoughSpace.rawValue:
+      return FlutterError(code: "NOT_ENOUGH_SPACE", message: message, details: details)
+
+    default:
+      return FlutterError(code: "UNEXPECTED", message: message, details: details)
     }
   }
+}
+
+/// Low iOS versions do not have an enum defined, so [rawValue] must be used.
+/// If [rawValue] is not defined either, no handle is possible.
+/// You can check Apple's documentation by replacing the [$caseName] of the following URL
+/// Some documents are not provided by Apple.
+/// https://developer.apple.com/documentation/photokit/phphotoserror/code/$caseName
+enum PHErrorCode: Int {
+
+  // [PHPhotosError.identifierNotFound]
+  case identifierNotFound = 3201
+
+  // [PHPhotosError.multipleIdentifiersFound]
+  case multipleIdentifiersFound = 3202
+
+  // Apple has not released documentation.
+  case videoConversionFailed = 3300
+
+  // Apple has not released documentation.
+  case unsupportedVideoCodecs = 3302
+
+  // [PHPhotosError.notEnoughSpace]
+  case notEnoughSpace = 3305
+
+  // [PHPhotosError.requestNotSupportedForAsset]
+  case requestNotSupportedForAsset = 3306
+
+  // [PHPhotosError.accessRestricted]
+  case accessRestricted = 3310
+
+  // [PHPhotosError.accessUserDenied]
+  case accessUserDenied = 3311
 }

--- a/lib/src/gal_exception.dart
+++ b/lib/src/gal_exception.dart
@@ -39,8 +39,7 @@ enum GalExceptionType {
   /// When an error occurs with unexpected.
   unexpected,
 
-  /// When an error occurs under iOS15.
-  /// Under iOS 15, it is not possible to get details of errors on saving.
+  @Deprecated('Use [unexpected] instead. For more info at ')
   notHandle;
 
   String get code => switch (this) {
@@ -48,7 +47,7 @@ enum GalExceptionType {
         notEnoughSpace => 'NOT_ENOUGH_SPACE',
         notSupportedFormat => 'NOT_SUPPORTED_FORMAT',
         unexpected => 'UNEXPECTED',
-        notHandle => 'NOT_HANDLE',
+        _ => 'NOT_HANDLE',
       };
 
   String get message => switch (this) {
@@ -56,6 +55,6 @@ enum GalExceptionType {
         notEnoughSpace => 'Not enough space for storage.',
         notSupportedFormat => 'Unsupported file formats.',
         unexpected => 'An unexpected error has occurred.',
-        notHandle => 'An unexpected error has occurred.',
+        _ => 'An unexpected error has occurred.',
       };
 }

--- a/lib/src/gal_exception.dart
+++ b/lib/src/gal_exception.dart
@@ -24,7 +24,6 @@ class GalException implements Exception {
 }
 
 enum GalExceptionType {
-
   /// When Has no permission to access gallery app.
   accessDenied,
 
@@ -39,7 +38,8 @@ enum GalExceptionType {
   /// When an error occurs with unexpected.
   unexpected,
 
-  @Deprecated('Use [unexpected] instead. For more info at ')
+  @Deprecated(
+      'Use [unexpected] instead. https://github.com/natsuk4ze/gal/pull/25')
   notHandle;
 
   String get code => switch (this) {


### PR DESCRIPTION
## Overview
Enable error handling in lower iOS versions.
This is accomplished by using error codes directly, but if the error code is not even implemented in the low iOS version, api 
will `throw` `GalExceptionType.unexpected`. However, in most cases, you will be able to handle the error handling correctly.

__In the next major version, `GalExceptionType.unexpected` will be removed.__

- [x] I read the [Contributor Guide](https://github.com/natsuk4ze/gal/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.

## Related Issues

- Close #24 
