### PR TITLE
Update to 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.0
+
+* ADD: Support for AGP 8 #118
+
 ## 1.8.6
 
 * UPDATE: Keep file name when saving #115

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gal_example
 description: Demonstrates how to use the gal plugin.
-version: 1.8.6
+version: 1.9.0
 publish_to: none
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gal
 description: Gal is a Flutter plugin for saving image/video to gallary app. You can also easily handle permissions.
-version: 1.8.6
+version: 1.9.0
 homepage: https://pub.dev/packages/gal
 repository: https://github.com/natsuk4ze/gal
 


### PR DESCRIPTION
## ⚠️ [Pub.dev](https://pub.dev/packages/gal) is currently broken for dart-lang/pub-dev#6953, this will land when dart-lang/pub-dev#6954 merged.