### PR TITLE
Solve the bug that sometimes the header file cannot be referenced

### DIFF
--- a/darwin/Classes/Gal.h
+++ b/darwin/Classes/Gal.h
@@ -1,0 +1,13 @@
+//
+//  Gal.h
+//  gal
+//
+//  Created by liyuanbo on 2023/10/10.
+//
+
+#import <Flutter/Flutter.h>
+
+@interface Gal : NSObject <FlutterPlugin>
+
+@end
+

--- a/darwin/Classes/Gal.h
+++ b/darwin/Classes/Gal.h
@@ -5,7 +5,11 @@
 //  Created by liyuanbo on 2023/10/10.
 //
 
+#if TARGET_OS_IOS
 #import <Flutter/Flutter.h>
+#else
+#import <FlutterMacOS/FlutterMacOS.h>
+#endif
 
 @interface Gal : NSObject <FlutterPlugin>
 

--- a/darwin/Classes/Gal.m
+++ b/darwin/Classes/Gal.m
@@ -1,0 +1,26 @@
+//
+//  Gal.m
+//  gal
+//
+//  Created by liyuanbo on 2023/10/10.
+//
+
+#import "Gal.h"
+
+#if __has_include(<Gal/Gal-Swift.h>)
+#import <Gal/Gal-Swift.h>
+#else
+// Support project import fallback if the generated compatibility header
+// is not copied when this plugin is created as a library.
+// https://forums.swift.org/t/swift-static-libraries-dont-copy-generated-objective-c-header/19816
+#import "gal-Swift.h"
+#endif
+
+@implementation Gal
+
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar
+{
+    [GalPlugin registerWithRegistrar:registrar];
+}
+
+@end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,10 +35,10 @@ flutter:
         package: studio.midoridesign.gal
         pluginClass: GalPlugin
       ios:
-        pluginClass: GalPlugin
+        pluginClass: Gal
         sharedDarwinSource: true
       macos:
-        pluginClass: GalPlugin
+        pluginClass: Gal
         sharedDarwinSource: true
       windows:
         pluginClass: GalPluginCApi


### PR DESCRIPTION
Solve the bug that sometimes the header file cannot be referenced

## Overview

_Please change this text to a brief statement of purpose or overview._

- [x] I read the [Contributor Guide](https://github.com/natsuk4ze/gal/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.

## Related Issues

-  [Support project import fallback if the generated compatibility header is not copied when this plugin is created as a library.](https://forums.swift.org/t/swift-static-libraries-dont-copy-generated-objective-c-header/19816)
