### PR TITLE
Reduce Pacakge Download Size

### DIFF
--- a/example/assets/.pubignore
+++ b/example/assets/.pubignore
@@ -1,0 +1,2 @@
+done.jpg
+done.mp4


### PR DESCRIPTION
### This change brings the package size from 1 MB to 500 KB.

The assets in the example folder is required to run the example code, but not for package users.

Basically, package users clone the repository when they run example, so we should add it to .pubignore.

See:
- [stackoverflow](https://stackoverflow.com/questions/69760021/what-should-be-ignored-in-darts-pubignore/69767697#69767697)
- #175

