### PR TITLE
Remove snapshot saving form avd cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,20 +158,6 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}
  
-      - name: Create AVD and generate snapshot for caching
-        if: steps.cache-avd.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
-        timeout-minutes: 20
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          arch: x86_64
-          emulator-boot-timeout: 300
-          disable-spellchecker: true
-          force-avd-creation: false
-          sdcard-path-or-size: ${{ matrix.api-level < 29 && '10M' || null }}
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
-          script: echo "Generated AVD snapshot for caching."
- 
       # Retry: Integration testing with GitHub Actions is unstable.
       - name: Run integration tests
         id: Run-integration-tests
@@ -182,7 +168,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           working-directory: ./example
           arch: x86_64
-          emulator-boot-timeout: 180
+          emulator-boot-timeout: 200
           disable-spellchecker: true
           force-avd-creation: false
           sdcard-path-or-size: ${{ matrix.api-level < 29 && '10M' || null }}
@@ -202,7 +188,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           working-directory: ./example
           arch: x86_64
-          emulator-boot-timeout: 180
+          emulator-boot-timeout: 200
           disable-spellchecker: true
           force-avd-creation: false
           sdcard-path-or-size: ${{ matrix.api-level < 29 && '10M' || null }}
@@ -224,7 +210,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           working-directory: ./example
           arch: x86_64
-          emulator-boot-timeout: 180
+          emulator-boot-timeout: 200
           disable-spellchecker: true
           force-avd-creation: false
           sdcard-path-or-size: ${{ matrix.api-level < 29 && '10M' || null }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,105 +17,105 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-  windows:
-    needs: set-up
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        windows-version: [10]
-      fail-fast: false
-    runs-on: windows-latest
-    steps:
-      - name: Check out
-        uses: actions/checkout@v4
-
-      - name: Setup Flutter SDK
-        timeout-minutes: 10
-        uses: subosito/flutter-action@v2
-        with:
-          channel: beta
-
-      - name: Run integration tests
-        id: Run-integration-tests
-        timeout-minutes: 15
-        run: |
-          cd example
-          flutter test integration_test/integration_test.dart windows
-
-  macos:
-    needs: set-up
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        macos-version: [13]
-      fail-fast: false
-    runs-on: macos-${{ matrix.macos-version }}
-    steps:
-      - name: Check out
-        uses: actions/checkout@v4
-
-      - name: Setup Flutter SDK
-        timeout-minutes: 10
-        uses: subosito/flutter-action@v2
-        with:
-          channel: beta
-
-      - name: Run integration tests
-        id: Run-integration-tests
-        timeout-minutes: 15
-        run: |
-          cd example
-          flutter test integration_test/integration_test.dart macos
-
-  ios:
-    needs: set-up
-    timeout-minutes: 60
-    strategy:
-      matrix:
-        ios-version: [16]
-      fail-fast: false
-    runs-on: macos-13
-    steps:
-      - name: Check out
-        uses: actions/checkout@v4
-
-      - name: Setup Flutter SDK
-        timeout-minutes: 10
-        uses: subosito/flutter-action@v2
-        with:
-          channel: beta
-
-      - name: Boot ios simulator
-        uses: futureware-tech/simulator-action@v2
-        with:
-          model: iPhone 14 Pro Max
-          os_version: ^${{ matrix.ios-version }}
-      
-      - name: Grant permission
-        run: |
-          brew tap wix/brew
-          brew install applesimutils
-          cd example
-          applesimutils --booted --bundle studio.midoridesign.galExample --setPermissions photos=YES
-
-      - name: Run integration tests
-        id: Run-integration-tests
-        continue-on-error: true
-        timeout-minutes: 15
-        run: |
-          cd example
-          flutter test integration_test/integration_test.dart
-
-      # Retry: Integration testing with GitHub Actions is unstable.
-      - name: Retry integration tests
-        id: Retry-integration-tests
-        timeout-minutes: 15
-        if: steps.Run-integration-tests.outcome == 'failure'
-        run: |
-          flutter clean && flutter pub get
-          cd example
-          flutter clean && flutter pub get
-          flutter test integration_test/integration_test.dart
+#  windows:
+#    needs: set-up
+#    timeout-minutes: 30
+#    strategy:
+#      matrix:
+#        windows-version: [10]
+#      fail-fast: false
+#    runs-on: windows-latest
+#    steps:
+#      - name: Check out
+#        uses: actions/checkout@v4
+#
+#      - name: Setup Flutter SDK
+#        timeout-minutes: 10
+#        uses: subosito/flutter-action@v2
+#        with:
+#          channel: beta
+#
+#      - name: Run integration tests
+#        id: Run-integration-tests
+#        timeout-minutes: 15
+#        run: |
+#          cd example
+#          flutter test integration_test/integration_test.dart windows
+#
+#  macos:
+#    needs: set-up
+#    timeout-minutes: 30
+#    strategy:
+#      matrix:
+#        macos-version: [13]
+#      fail-fast: false
+#    runs-on: macos-${{ matrix.macos-version }}
+#    steps:
+#      - name: Check out
+#        uses: actions/checkout@v4
+#
+#      - name: Setup Flutter SDK
+#        timeout-minutes: 10
+#        uses: subosito/flutter-action@v2
+#        with:
+#          channel: beta
+#
+#      - name: Run integration tests
+#        id: Run-integration-tests
+#        timeout-minutes: 15
+#        run: |
+#          cd example
+#          flutter test integration_test/integration_test.dart macos
+#
+#  ios:
+#    needs: set-up
+#    timeout-minutes: 60
+#    strategy:
+#      matrix:
+#        ios-version: [16]
+#      fail-fast: false
+#    runs-on: macos-13
+#    steps:
+#      - name: Check out
+#        uses: actions/checkout@v4
+#
+#      - name: Setup Flutter SDK
+#        timeout-minutes: 10
+#        uses: subosito/flutter-action@v2
+#        with:
+#          channel: beta
+#
+#      - name: Boot ios simulator
+#        uses: futureware-tech/simulator-action@v2
+#        with:
+#          model: iPhone 14 Pro Max
+#          os_version: ^${{ matrix.ios-version }}
+#      
+#      - name: Grant permission
+#        run: |
+#          brew tap wix/brew
+#          brew install applesimutils
+#          cd example
+#          applesimutils --booted --bundle studio.midoridesign.galExample --setPermissions photos=YES
+#
+#      - name: Run integration tests
+#        id: Run-integration-tests
+#        continue-on-error: true
+#        timeout-minutes: 15
+#        run: |
+#          cd example
+#          flutter test integration_test/integration_test.dart
+#
+#      # Retry: Integration testing with GitHub Actions is unstable.
+#      - name: Retry integration tests
+#        id: Retry-integration-tests
+#        timeout-minutes: 15
+#        if: steps.Run-integration-tests.outcome == 'failure'
+#        run: |
+#          flutter clean && flutter pub get
+#          cd example
+#          flutter clean && flutter pub get
+#          flutter test integration_test/integration_test.dart
 
   android:
     needs: set-up
@@ -138,7 +138,7 @@ jobs:
         run: flutter pub get ./example
  
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
@@ -167,7 +167,6 @@ jobs:
           arch: x86_64
           emulator-boot-timeout: 300
           disable-spellchecker: true
-          disk-size: 2048M
           force-avd-creation: false
           sdcard-path-or-size: ${{ matrix.api-level < 29 && '10M' || null }}
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
@@ -185,7 +184,6 @@ jobs:
           arch: x86_64
           emulator-boot-timeout: 180
           disable-spellchecker: true
-          disk-size: 2048M
           force-avd-creation: false
           sdcard-path-or-size: ${{ matrix.api-level < 29 && '10M' || null }}
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
@@ -207,7 +205,6 @@ jobs:
           emulator-boot-timeout: 180
           disable-spellchecker: true
           force-avd-creation: false
-          disk-size: 2048M
           sdcard-path-or-size: ${{ matrix.api-level < 29 && '10M' || null }}
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
           pre-emulator-launch-script: |
@@ -230,7 +227,6 @@ jobs:
           emulator-boot-timeout: 180
           disable-spellchecker: true
           force-avd-creation: false
-          disk-size: 2048M
           sdcard-path-or-size: ${{ matrix.api-level < 29 && '10M' || null }}
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
           pre-emulator-launch-script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,105 +17,105 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-#  windows:
-#    needs: set-up
-#    timeout-minutes: 30
-#    strategy:
-#      matrix:
-#        windows-version: [10]
-#      fail-fast: false
-#    runs-on: windows-latest
-#    steps:
-#      - name: Check out
-#        uses: actions/checkout@v4
-#
-#      - name: Setup Flutter SDK
-#        timeout-minutes: 10
-#        uses: subosito/flutter-action@v2
-#        with:
-#          channel: beta
-#
-#      - name: Run integration tests
-#        id: Run-integration-tests
-#        timeout-minutes: 15
-#        run: |
-#          cd example
-#          flutter test integration_test/integration_test.dart windows
-#
-#  macos:
-#    needs: set-up
-#    timeout-minutes: 30
-#    strategy:
-#      matrix:
-#        macos-version: [13]
-#      fail-fast: false
-#    runs-on: macos-${{ matrix.macos-version }}
-#    steps:
-#      - name: Check out
-#        uses: actions/checkout@v4
-#
-#      - name: Setup Flutter SDK
-#        timeout-minutes: 10
-#        uses: subosito/flutter-action@v2
-#        with:
-#          channel: beta
-#
-#      - name: Run integration tests
-#        id: Run-integration-tests
-#        timeout-minutes: 15
-#        run: |
-#          cd example
-#          flutter test integration_test/integration_test.dart macos
-#
-#  ios:
-#    needs: set-up
-#    timeout-minutes: 60
-#    strategy:
-#      matrix:
-#        ios-version: [16]
-#      fail-fast: false
-#    runs-on: macos-13
-#    steps:
-#      - name: Check out
-#        uses: actions/checkout@v4
-#
-#      - name: Setup Flutter SDK
-#        timeout-minutes: 10
-#        uses: subosito/flutter-action@v2
-#        with:
-#          channel: beta
-#
-#      - name: Boot ios simulator
-#        uses: futureware-tech/simulator-action@v2
-#        with:
-#          model: iPhone 14 Pro Max
-#          os_version: ^${{ matrix.ios-version }}
-#      
-#      - name: Grant permission
-#        run: |
-#          brew tap wix/brew
-#          brew install applesimutils
-#          cd example
-#          applesimutils --booted --bundle studio.midoridesign.galExample --setPermissions photos=YES
-#
-#      - name: Run integration tests
-#        id: Run-integration-tests
-#        continue-on-error: true
-#        timeout-minutes: 15
-#        run: |
-#          cd example
-#          flutter test integration_test/integration_test.dart
-#
-#      # Retry: Integration testing with GitHub Actions is unstable.
-#      - name: Retry integration tests
-#        id: Retry-integration-tests
-#        timeout-minutes: 15
-#        if: steps.Run-integration-tests.outcome == 'failure'
-#        run: |
-#          flutter clean && flutter pub get
-#          cd example
-#          flutter clean && flutter pub get
-#          flutter test integration_test/integration_test.dart
+  windows:
+    needs: set-up
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        windows-version: [10]
+      fail-fast: false
+    runs-on: windows-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter SDK
+        timeout-minutes: 10
+        uses: subosito/flutter-action@v2
+        with:
+          channel: beta
+
+      - name: Run integration tests
+        id: Run-integration-tests
+        timeout-minutes: 15
+        run: |
+          cd example
+          flutter test integration_test/integration_test.dart windows
+
+  macos:
+    needs: set-up
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        macos-version: [13]
+      fail-fast: false
+    runs-on: macos-${{ matrix.macos-version }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter SDK
+        timeout-minutes: 10
+        uses: subosito/flutter-action@v2
+        with:
+          channel: beta
+
+      - name: Run integration tests
+        id: Run-integration-tests
+        timeout-minutes: 15
+        run: |
+          cd example
+          flutter test integration_test/integration_test.dart macos
+
+  ios:
+    needs: set-up
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        ios-version: [16]
+      fail-fast: false
+    runs-on: macos-13
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter SDK
+        timeout-minutes: 10
+        uses: subosito/flutter-action@v2
+        with:
+          channel: beta
+
+      - name: Boot ios simulator
+        uses: futureware-tech/simulator-action@v2
+        with:
+          model: iPhone 14 Pro Max
+          os_version: ^${{ matrix.ios-version }}
+      
+      - name: Grant permission
+        run: |
+          brew tap wix/brew
+          brew install applesimutils
+          cd example
+          applesimutils --booted --bundle studio.midoridesign.galExample --setPermissions photos=YES
+
+      - name: Run integration tests
+        id: Run-integration-tests
+        continue-on-error: true
+        timeout-minutes: 15
+        run: |
+          cd example
+          flutter test integration_test/integration_test.dart
+
+      # Retry: Integration testing with GitHub Actions is unstable.
+      - name: Retry integration tests
+        id: Retry-integration-tests
+        timeout-minutes: 15
+        if: steps.Run-integration-tests.outcome == 'failure'
+        run: |
+          flutter clean && flutter pub get
+          cd example
+          flutter clean && flutter pub get
+          flutter test integration_test/integration_test.dart
 
   android:
     needs: set-up

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ### Please [LIKE👍](https://pub.dev/packages/gal) and [STAR⭐️](https://github.com/natsuk4ze/gal) to support our volunteer efforts.
 
 
-**Support** means that all functions have been tested manually or [automatically](https://github.com/natsuk4ze/gal/actions/runs/7517751549).
+**Support** means that all functions have been tested manually or [automatically](https://github.com/natsuk4ze/gal/actions/runs/7517751549) whenever possible.
 |             | Android | iOS | macOS | Windows | Linux |
 |-------------|---------|-----|-------|---------|-------|
 | **Support** | SDK 21+ | 11+ |  11+  |   10+   | See: [gal_linux](https://pub.dev/packages/gal_linux) |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ### Please [LIKE👍](https://pub.dev/packages/gal) and [STAR⭐️](https://github.com/natsuk4ze/gal) to support our volunteer efforts.
 
 
-**Support** means that all possible versions have been [tested automatically](https://github.com/natsuk4ze/gal/actions/runs/7517751549).
+**Support** means that all functions have been tested manually or [automatically](https://github.com/natsuk4ze/gal/actions/runs/7517751549).
 |             | Android | iOS | macOS | Windows | Linux |
 |-------------|---------|-----|-------|---------|-------|
 | **Support** | SDK 21+ | 11+ |  11+  |   10+   | See: [gal_linux](https://pub.dev/packages/gal_linux) |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 
 ### Please [LIKE👍](https://pub.dev/packages/gal) and [STAR⭐️](https://github.com/natsuk4ze/gal) to support our volunteer efforts.
 
+
+**Support** means that all possible versions have been [tested automatically](https://github.com/natsuk4ze/gal/actions/runs/7517751549).
 |             | Android | iOS | macOS | Windows | Linux |
 |-------------|---------|-----|-------|---------|-------|
 | **Support** | SDK 21+ | 11+ |  11+  |   10+   | See: [gal_linux](https://pub.dev/packages/gal_linux) |
@@ -101,10 +103,9 @@ Update [Visual Studio](https://visualstudio.microsoft.com) to the latest version
 
 > **💡 If you can't compile**
 > 
-> Try downloading a latest Windows SDK
-> Here are the steps:
+> Try downloading a latest Windows SDK:
 > 1. Open Visual Studio Installer
-> 2. Select Mofify
+> 2. Select Modify
 > 3. Select Windows SDK
 
 ### Linux
@@ -172,13 +173,15 @@ await Gal.putVideo(video.path);
 ### Handle Permission
 
 ```dart
-// Handle Permission
-await Gal.hasAccess();
+// Check for access premission
+final hasAccess = await Gal.hasAccess();
+
+// Request access premission
 await Gal.requestAccess();
 
-// Handle Permission for saving to album
-await Gal.hasAccess(toAlbum:true);
-await Gal.requestAccess(toAlbum:true);
+// ... for saving to album
+final hasAccess = await Gal.hasAccess(toAlbum: true);
+await Gal.requestAccess(toAlbum: true);
 ```
 
 ### Handle Errors
@@ -220,6 +223,7 @@ If you write an article about Gal, let us know in discussion and we will post th
 ## 💚 Trusted by huge projects
 Although Gal has only been released for a short time, it is already trusted by huge projects.
 
-- ### [localsend - 23k⭐️](https://github.com/localsend/localsend)
+- ### [localsend - 27k⭐️](https://github.com/localsend/localsend)
 - ### [flutter-quill-extensions - 2.2k⭐️](https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_extensions)
+- ### [Thunder - 650⭐️](https://github.com/thunder-app/thunder)
 and more...

--- a/lib/src/gal_exception.dart
+++ b/lib/src/gal_exception.dart
@@ -9,8 +9,18 @@ class GalException implements Exception {
     required this.platformException,
     required this.stackTrace,
   });
+
+  /// Type of error.
+  /// 
+  /// See: [GalExceptionType]
   final GalExceptionType type;
+
+  /// Native code error information.
   final PlatformException platformException;
+
+  /// Stack trace of the error in dart side.
+  /// 
+  /// The native code StackTrace is stored in [PlatformException.stacktrace].
   final StackTrace stackTrace;
 
   factory GalException.fromCode({
@@ -23,21 +33,22 @@ class GalException implements Exception {
       orElse: () => GalExceptionType.unexpected,
     );
     return GalException(
-        type: type,
-        platformException: platformException,
-        stackTrace: stackTrace);
+      type: type,
+      platformException: platformException,
+      stackTrace: stackTrace,
+    );
   }
+
   @override
   String toString() => "[GalException/${type.code}]: ${type.message}";
 }
 
 /// Types of [GalException]
 ///
-/// Except for [accessDenied] is best effort and is not always
-/// classified and may return [unexpected].
-/// In that case, you can get support by submitting 
+/// If the type cannot be determined, it will be [unexpected].
+/// In that case, you can get support by submitting
 /// an [issue](https://github.com/natsuk4ze/gal/issues)
-/// including all values of [GalException.platformException] 
+/// including all values of [GalException.platformException]
 /// and [GalException.stackTrace].
 enum GalExceptionType {
 
@@ -52,7 +63,7 @@ enum GalExceptionType {
   /// See: https://github.com/natsuk4ze/gal/wiki/Formats
   notSupportedFormat,
 
-  /// When an error occurs with unexpected (could not classified).
+  /// When an error occurs with unexpected.
   unexpected;
 
   String get code => switch (this) {


### PR DESCRIPTION
The cache limit for GitHub Actions is 10 GB, and storing an avd cache containing snapshots will exceed the limit. Storing cache beyond the limit may cause integrity issues, so the cache size should be reduced.