### PR TITLE
Fix Failed to build unique file in Android

### DIFF
--- a/android/src/main/java/studio/midoridesign/gal/GalPlugin.java
+++ b/android/src/main/java/studio/midoridesign/gal/GalPlugin.java
@@ -152,18 +152,17 @@ public class GalPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwar
     // See: https://github.com/natsuk4ze/gal/issues/198
     private Uri getUniqueFileUri(ContentResolver resolver, ContentValues values, boolean isImage,
             String name, String extension) throws IllegalStateException {
-        Uri uri = null;
         int suffix = 0;
-
-        while (uri == null) {
+        while (true) {
             try {
-                uri = resolver.insert(isImage ? IMAGE_URI : VIDEO_URI, values);
+                values.put(MediaStore.MediaColumns.DISPLAY_NAME,
+                        name + (suffix > 0 ? suffix : "") + extension);
+                return resolver.insert(isImage ? IMAGE_URI : VIDEO_URI, values);
             } catch (IllegalStateException e) {
                 if (!e.getMessage().contains("Failed to build unique file")) throw e;
-                values.put(MediaStore.MediaColumns.DISPLAY_NAME, name + (++suffix) + extension);
+                suffix++;
             }
         }
-        return uri;
     }
 
     @SuppressWarnings("EmptyStatementCheck")

--- a/android/src/main/java/studio/midoridesign/gal/GalPlugin.java
+++ b/android/src/main/java/studio/midoridesign/gal/GalPlugin.java
@@ -152,15 +152,13 @@ public class GalPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwar
     // See: https://github.com/natsuk4ze/gal/issues/198
     private Uri getUniqueFileUri(ContentResolver resolver, ContentValues values, boolean isImage,
             String name, String extension) throws IllegalStateException {
-        int suffix = 0;
-        while (true) {
+        for (int suffix = 0;; suffix++) {
             try {
                 values.put(MediaStore.MediaColumns.DISPLAY_NAME,
                         name + (suffix > 0 ? suffix : "") + extension);
                 return resolver.insert(isImage ? IMAGE_URI : VIDEO_URI, values);
             } catch (IllegalStateException e) {
                 if (!e.getMessage().contains("Failed to build unique file")) throw e;
-                suffix++;
             }
         }
     }


### PR DESCRIPTION
## Fix: "Failed to build unique file" in Android

FileUtils.java only checks up to 31 times to generate a unique name, so it needs handling the "Failed to build unique file" error and generate unique names until it succeeds.

See: https://takusan.negitoro.dev/posts/android_unique_file/

Close #198 

🗒️ Note
Suffix should be like `image (32).jpg` to match the Android system, But it was not possible because duplicate checking is done in the MediaStore system, so it would look like `image (32)(1).jpg`.