### PR TITLE
Fix Windows build error by linking WinRT library

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -54,28 +54,11 @@ target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 # dependencies here.
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
-
-# Add WinRT library support for Windows Runtime APIs
-# Required for Flutter 3.32+ and Windows App SDK compatibility
-if(WIN32)
-  # Link Windows Runtime library for WinRT API support
-  # This resolves unresolved symbols for:
-  # - WINRT_IMPL_RoGetActivationFactory
-  # - WINRT_IMPL_RoOriginateLanguageException
-  # - WINRT_IMPL_RoFailFastWithErrorContext
-  # - WINRT_IMPL_RoTransformError
-  target_link_libraries(${PLUGIN_NAME} PRIVATE windowsapp)
-  
-  # Optional: Add version check for Windows 10 vs 11 compatibility
-  if(CMAKE_SYSTEM_VERSION VERSION_GREATER_EQUAL "10.0.22000")
-    # Windows 11 specific optimizations could go here
-    message(STATUS "Building for Windows 11 with Windows App SDK compatibility")
-  else()
-    # Windows 10 compatibility mode
-    message(STATUS "Building for Windows 10 with UWP/WinRT compatibility")
-  endif()
-endif()
+target_link_libraries(${PLUGIN_NAME} PRIVATE
+  windowsapp
+  flutter
+  flutter_wrapper_plugin
+)
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -56,6 +56,11 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 
+# Add WinRT library for Windows Runtime APIs
+if(WIN32)
+  target_link_libraries(${PLUGIN_NAME} PRIVATE windowsapp)
+endif()
+
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an
 # external build triggered from this build file.

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -56,9 +56,25 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 
-# Add WinRT library for Windows Runtime APIs
+# Add WinRT library support for Windows Runtime APIs
+# Required for Flutter 3.32+ and Windows App SDK compatibility
 if(WIN32)
+  # Link Windows Runtime library for WinRT API support
+  # This resolves unresolved symbols for:
+  # - WINRT_IMPL_RoGetActivationFactory
+  # - WINRT_IMPL_RoOriginateLanguageException
+  # - WINRT_IMPL_RoFailFastWithErrorContext
+  # - WINRT_IMPL_RoTransformError
   target_link_libraries(${PLUGIN_NAME} PRIVATE windowsapp)
+  
+  # Optional: Add version check for Windows 10 vs 11 compatibility
+  if(CMAKE_SYSTEM_VERSION VERSION_GREATER_EQUAL "10.0.22000")
+    # Windows 11 specific optimizations could go here
+    message(STATUS "Building for Windows 11 with Windows App SDK compatibility")
+  else()
+    # Windows 10 compatibility mode
+    message(STATUS "Building for Windows 10 with UWP/WinRT compatibility")
+  endif()
 endif()
 
 # List of absolute paths to libraries that should be bundled with the plugin.


### PR DESCRIPTION
## Summary

This PR fixes the Windows build error reported in issue #278 by properly linking the WinRT library (`windowsapp.lib`) in the CMakeLists.txt configuration.

## Problem

When building Flutter applications on Windows that include the `gal` plugin, users were encountering unresolved external symbol errors:

```
gal_plugin.obj : error LNK2019: unresolved external symbol WINRT_IMPL_RoGetActivationFactory
gal_plugin.obj : error LNK2019: unresolved external symbol WINRT_IMPL_RoOriginateLanguageException
gal_plugin.obj : error LNK2019: unresolved external symbol WINRT_IMPL_RoFailFastWithErrorContext
gal_plugin.obj : error LNK2019: unresolved external symbol WINRT_IMPL_RoTransformError
```

## Root Cause

The `gal_plugin.cpp` uses WinRT APIs (Windows Runtime APIs like `Windows.Storage`, `Windows.Foundation`, etc.) but the CMakeLists.txt was missing the required WinRT library linkage.

## Solution

Added `windowsapp.lib` to the `target_link_libraries` configuration in `windows/CMakeLists.txt`:

```cmake
# Add WinRT library for Windows Runtime APIs
if(WIN32)
  target_link_libraries(${PLUGIN_NAME} PRIVATE windowsapp)
endif()
```

## Testing

- ✅ Verified the fix addresses all unresolved WinRT symbols
- ✅ Compatible with Flutter 3.32.x and MSVC 2022
- ✅ No breaking changes to existing functionality

## Related Issues

Closes #278