### PR TITLE
feat: Add manual trigger support for individual platform CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,58 @@ on:
     inputs:
       run_all:
         type: boolean
-        description: 'Run all jobs regardless of path filters'
+        description: "Run all jobs regardless of path filters"
+        required: false
+        default: false
+      run_windows:
+        type: boolean
+        description: "Run Windows tests"
+        required: false
+        default: false
+      run_macos:
+        type: boolean
+        description: "Run macOS tests"
+        required: false
+        default: false
+      run_ios:
+        type: boolean
+        description: "Run iOS tests"
+        required: false
+        default: false
+      run_android:
+        type: boolean
+        description: "Run Android tests"
         required: false
         default: false
   workflow_call:
     inputs:
       run_all:
         type: boolean
-        description: 'Run all jobs regardless of path filters'
+        description: "Run all jobs regardless of path filters"
+        required: false
+        default: false
+      run_windows:
+        type: boolean
+        description: "Run Windows tests"
+        required: false
+        default: false
+      run_macos:
+        type: boolean
+        description: "Run macOS tests"
+        required: false
+        default: false
+      run_ios:
+        type: boolean
+        description: "Run iOS tests"
+        required: false
+        default: false
+      run_android:
+        type: boolean
+        description: "Run Android tests"
         required: false
         default: false
 
-jobs:  
+jobs:
   filter:
     runs-on: ubuntu-latest
     outputs:
@@ -59,20 +99,20 @@ jobs:
 
   windows:
     needs: filter
-    if: ${{ needs.filter.outputs.windows_changed == 'true' || needs.filter.outputs.common_changed == 'true' || inputs.run_all }}
+    if: ${{ needs.filter.outputs.windows_changed == 'true' || needs.filter.outputs.common_changed == 'true' || inputs.run_all || inputs.run_windows }}
     uses: ./.github/workflows/ci_windows.yml
 
   macos:
     needs: filter
-    if: ${{ needs.filter.outputs.macos_changed == 'true' || needs.filter.outputs.common_changed == 'true' || inputs.run_all }}
+    if: ${{ needs.filter.outputs.macos_changed == 'true' || needs.filter.outputs.common_changed == 'true' || inputs.run_all || inputs.run_macos }}
     uses: ./.github/workflows/ci_macos.yml
 
   ios:
     needs: filter
-    if: ${{ needs.filter.outputs.ios_changed == 'true' || needs.filter.outputs.common_changed == 'true' || inputs.run_all }}
+    if: ${{ needs.filter.outputs.ios_changed == 'true' || needs.filter.outputs.common_changed == 'true' || inputs.run_all || inputs.run_ios }}
     uses: ./.github/workflows/ci_ios.yml
 
   android:
     needs: filter
-    if: ${{ needs.filter.outputs.android_changed == 'true' || needs.filter.outputs.common_changed == 'true' || inputs.run_all }}
+    if: ${{ needs.filter.outputs.android_changed == 'true' || needs.filter.outputs.common_changed == 'true' || inputs.run_all || inputs.run_android }}
     uses: ./.github/workflows/ci_android.yml

--- a/.github/workflows/ci_android.yml
+++ b/.github/workflows/ci_android.yml
@@ -2,6 +2,7 @@ name: Android Integration Tests
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   android:

--- a/.github/workflows/ci_ios.yml
+++ b/.github/workflows/ci_ios.yml
@@ -2,6 +2,7 @@ name: iOS Integration Tests
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   ios:
@@ -52,7 +53,7 @@ jobs:
         run: |
           cd example
           flutter test integration_test/integration_test.dart
-      
+
       - name: Retry integration tests
         if: steps.Run-integration-tests.outcome == 'failure'
         timeout-minutes: 15

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -2,6 +2,7 @@ name: macOS Integration Tests
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   macos:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -2,15 +2,16 @@ name: Windows Integration Tests
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   windows:
     runs-on: windows-latest
     timeout-minutes: 30
     strategy:
-        matrix:
-          windows-version: [10, 11]
-        fail-fast: false
+      matrix:
+        windows-version: [10, 11]
+      fail-fast: false
     steps:
       - name: Check out
         uses: actions/checkout@v4


### PR DESCRIPTION
## Overview
個別のプラットフォームでCIを手動実行できるように機能を追加しました。

## Changes
### Main CI Workflow (.github/workflows/ci.yml)
- workflow_dispatchに個別プラットフォーム選択オプションを追加:
  - run_windows: Windows CIを実行
  - run_macos: macOS CIを実行  
  - run_ios: iOS CIを実行
  - run_android: Android CIを実行
- 各プラットフォームジョブの条件分岐を更新し、手動選択をサポート

### Individual Platform Workflows
以下のワークフローにworkflow_dispatchを追加し、直接手動実行を可能にしました:
- .github/workflows/ci_windows.yml
- .github/workflows/ci_macos.yml
- .github/workflows/ci_ios.yml
- .github/workflows/ci_android.yml

## Usage
### メインCIワークフローから個別プラットフォーム実行
1. GitHubのActionsタブへ移動
2. CIワークフローを選択
3. Run workflowをクリック
4. 実行したいプラットフォームにチェックを入れて実行

### 個別ワークフローの直接実行
1. GitHubのActionsタブへ移動
2. 実行したいプラットフォームのワークフローを選択
3. Run workflowをクリックして実行

## Benefits
- 開発効率の向上：特定のプラットフォームのみをテストできるため、時間を節約
- 柔軟性の向上：必要なプラットフォームのみを選択して実行可能
- デバッグの効率化：問題のあるプラットフォームのみを集中的にテスト可能