### PR TITLE
fix: add windowsapp library linking for WinRT support in Windows build

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -54,7 +54,7 @@ target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 # dependencies here.
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin windowsapp)
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an


### PR DESCRIPTION
This PR fixes the Windows build failure reported in issue #278.

**Problem:**
The Windows build was failing with unresolved external symbols for WinRT functions:
- WINRT_IMPL_RoGetActivationFactory
- WINRT_IMPL_RoOriginateLanguageException
- WINRT_IMPL_RoFailFastWithErrorContext
- WINRT_IMPL_RoTransformError

**Solution:**
Added `windowsapp` library to target_link_libraries in windows/CMakeLists.txt to provide the required WinRT functions.

**Changes:**
- Modified `windows/CMakeLists.txt` to link the windowsapp library

Closes #278

Generated with [Claude Code](https://claude.ai/code)