### PR TITLE
Switch Android CI to Windows 2025 with Hyper-V acceleration

### DIFF
--- a/.github/workflows/ci_android.yml
+++ b/.github/workflows/ci_android.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   android:
-    runs-on: macos-13
+    runs-on: windows-2025
     timeout-minutes: 60
     strategy:
       matrix:
@@ -15,6 +15,14 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
+
+      - name: Enable Hyper-V and WHPX
+        shell: powershell
+        run: |
+          # Enable Hyper-V for Android emulation acceleration
+          Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -NoRestart
+          # Enable Windows Hypervisor Platform
+          Enable-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform -All -NoRestart
 
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
@@ -34,17 +42,24 @@ jobs:
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
-          path: ~/.gradle/caches
-          key: gradle
+          path: |
+            C:\Users\runneradmin\.gradle\caches
+            C:\Users\runneradmin\.gradle\wrapper
+            C:\Users\runneradmin\.android\.gradle
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
 
       - name: Cache AVD
         uses: actions/cache@v4
         id: cache-avd
         with:
           path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+            C:\Users\runneradmin\.android\avd\*
+            C:\Users\runneradmin\.android\adb*
+          key: avd-${{ runner.os }}-${{ matrix.api-level }}
+          restore-keys: |
+            avd-${{ runner.os }}-
 
       - name: Run integration tests
         id: Run-integration-tests
@@ -58,9 +73,11 @@ jobs:
           emulator-boot-timeout: 200
           disable-spellchecker: true
           force-avd-creation: false
-          disk-size: 4GB
+          disk-size: 8GB
+          ram-size: 6144M
+          heap-size: 1536M
           sdcard-path-or-size: ${{ matrix.api-level < 29 && '10M' || null }}
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
+          emulator-options: -accel on -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
           script: |
             if [ ${{ matrix.api-level }} -le 29 ]; then flutter build apk --debug; adb install -r build/app/outputs/flutter-apk/app-debug.apk; adb shell pm grant studio.midoridesign.gal_example android.permission.WRITE_EXTERNAL_STORAGE; adb shell pm grant studio.midoridesign.gal_example android.permission.READ_EXTERNAL_STORAGE; fi
             flutter test integration_test/integration_test.dart
@@ -78,9 +95,11 @@ jobs:
           emulator-boot-timeout: 200
           disable-spellchecker: true
           force-avd-creation: false
-          disk-size: 4GB
+          disk-size: 8GB
+          ram-size: 6144M
+          heap-size: 1536M
           sdcard-path-or-size: ${{ matrix.api-level < 29 && '10M' || null }}
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
+          emulator-options: -accel on -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
           pre-emulator-launch-script: |
             adb kill-server
             adb start-server
@@ -100,9 +119,11 @@ jobs:
           emulator-boot-timeout: 200
           disable-spellchecker: true
           force-avd-creation: false
-          disk-size: 4GB
+          disk-size: 8GB
+          ram-size: 6144M
+          heap-size: 1536M
           sdcard-path-or-size: ${{ matrix.api-level < 29 && '10M' || null }}
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
+          emulator-options: -accel on -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
           pre-emulator-launch-script: |
             adb kill-server
             adb start-server


### PR DESCRIPTION
## Summary
Enhanced Android CI workflow by switching to Windows 2025 runner with Hyper-V hardware acceleration and optimized Windows-specific configurations.

## Changes
- 🪟 **Windows 2025**: Upgrade from macOS-13 to latest Windows environment
- ⚡ **Hyper-V acceleration**: Enable Hyper-V and Windows Hypervisor Platform for hardware acceleration
- 📁 **Windows paths**: Update cache paths to Windows-specific directories
- 💾 **Enhanced storage**: Increase disk size from 4GB to 8GB
- 🧠 **Memory boost**: Upgrade RAM to 6144M (6GB) for memory-intensive operations  
- ⚡ **Heap optimization**: Enhance heap size to 1536M for better Java performance
- 🚀 **Hardware acceleration**: Add `-accel on` flag to all emulator options
- 🔄 **OS-specific caching**: Implement Windows-specific cache keys for better efficiency

## Expected Benefits
- **Latest Windows environment** with cutting-edge Windows 2025 features
- **Hyper-V acceleration** for improved Android emulation performance
- **Enhanced resource allocation** for complex multi-API level builds
- **Better Windows compatibility testing** for cross-platform verification
- **Optimized Windows performance** with platform-specific optimizations

## Technical Details
- Hyper-V and WHPX enablement for hardware-accelerated emulation
- Windows-specific cache paths (`C:\Users\runneradmin\`)
- PowerShell configuration for Windows environment setup
- 6GB RAM allocation ensures smooth operation across all API levels
- Enhanced caching with Windows-specific directory structures

## Test Plan
- [ ] Verify Windows 2025 runner compatibility
- [ ] Test Hyper-V acceleration functionality
- [ ] Validate across multiple API levels (21-34)
- [ ] Monitor execution time and resource utilization
- [ ] Ensure all integration tests pass on Windows platform

Alternative to PR #290 (ubuntu-latest) and PR #291 (macOS-15-xlarge) for comprehensive cross-platform testing.

🤖 Generated with [Claude Code](https://claude.ai/code)