### PR TITLE
Remove explicit ndkVersion from example app

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,6 @@ if (flutterVersionName == null) {
 android {
     namespace "studio.midoridesign.gal_example"
     compileSdk flutter.compileSdkVersion
-    ndkVersion flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11


### PR DESCRIPTION
## Summary
- Removed explicit `ndkVersion flutter.ndkVersion` from example app's build.gradle
- This allows Flutter to manage the NDK version automatically

## Background
The build was showing a warning about NDK version mismatch:
```
Your project is configured with Android NDK 26.3.11579264, but the following plugin(s) depend on a different Android NDK version:
- gal requires Android NDK 27.0.12077973
```

By removing the explicit NDK version from the example app, we let Flutter handle the NDK version management, which resolves the version mismatch warning.

## Test plan
- [x] Build runs without NDK version warnings
- [x] App launches successfully on Android emulator

🤖 Generated with [Claude Code](https://claude.ai/code)