### PR TITLE
feat: Automatically minimize old Claude review comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
     
@@ -30,6 +30,38 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Minimize old Claude reviews
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get PR number
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          
+          # Get all reviews for this PR
+          reviews=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews --jq '.[] | select(.user.login | contains("claude") or contains("bot")) | {id: .id, submitted_at: .submitted_at, body: .body}')
+          
+          # Get comment IDs that contain Claude signatures
+          comment_ids=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/comments --jq '.[] | select(.body | contains("Generated with Claude Code") or contains("🤖")) | {id: .node_id, created_at: .created_at}' | jq -s 'sort_by(.created_at) | reverse | .[1:] | .[].id' -r)
+          
+          # Minimize old comments using GraphQL API
+          for comment_id in $comment_ids; do
+            if [ ! -z "$comment_id" ]; then
+              gh api graphql -f query='
+                mutation($commentId: ID!) {
+                  minimizeComment(input: { 
+                    subjectId: $commentId, 
+                    classifier: OUTDATED 
+                  }) {
+                    minimizedComment {
+                      isMinimized
+                      minimizedReason
+                    }
+                  }
+                }' -f commentId="$comment_id" || true
+              echo "Minimized old Claude comment: $comment_id"
+            fi
+          done
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
## Summary
- Automatically minimize outdated Claude review comments before posting new reviews
- Use GitHub GraphQL API to mark old comments as OUTDATED
- Enhanced permissions to include pull-requests: write access
- Prevents comment clutter during review iterations

## Changes
- Added pre-review step to identify and minimize old Claude comments
- Updated workflow permissions to enable comment modification
- Implemented GraphQL mutation for comment minimization

## Test plan
- [ ] Deploy workflow changes
- [ ] Test with a sample PR that has multiple Claude reviews
- [ ] Verify old comments are properly minimized as "outdated"
- [ ] Confirm new reviews are posted normally

🤖 Generated with [Claude Code](https://claude.ai/code)