### PR TITLE
feat: implement breaking changes for v3

### DIFF
--- a/.github/workflows/ci_android.yml
+++ b/.github/workflows/ci_android.yml
@@ -14,6 +14,7 @@ jobs:
         # Source: https://github.com/flutter/flutter/blob/beta/packages/flutter_tools/gradle/src/main/kotlin/FlutterExtension.kt
         # Note: API level 30 is excluded due to persistent integration test failures (exit code 143)
         # The issue appears to be related to emulator stability on GitHub Actions runners
+        # Gal plugin minimum Android SDK version is 24
         api-level: [35, 34, 33, 32, 31, 29, 28, 27, 26, 25, 24]
       fail-fast: false
     steps:

--- a/.github/workflows/ci_ios.yml
+++ b/.github/workflows/ci_ios.yml
@@ -10,6 +10,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
+        # Gal plugin minimum iOS version is 13.0
         ios-version: [18]
         package_manager: [cocoapods, swiftpm]
       fail-fast: false

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ android {
     }
 
     defaultConfig {
-        minSdk 19
+        minSdk 24
     }
 
     dependencies {

--- a/darwin/gal.podspec
+++ b/darwin/gal.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.resource_bundles = {'gal_privacy' => ['gal/Sources/gal/PrivacyInfo.xcprivacy']}
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '11.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/lib/src/gal.dart
+++ b/lib/src/gal.dart
@@ -59,7 +59,7 @@ final class Gal {
   /// Use the [toAlbum] for additional permissions to save to an album.
   /// If you want to save to an album other than the one created by your app
   /// See: [Permissions](https://github.com/natsuk4ze/gal/wiki/Permissions)
-  static Future<bool> hasAccess({bool toAlbum = false}) async =>
+  static Future<bool> hasPermission({bool toAlbum = false}) async =>
       GalPlatform.instance.hasAccess(toAlbum: toAlbum);
 
   /// Request access permissions.
@@ -69,6 +69,6 @@ final class Gal {
   /// Use the [toAlbum] for additional permissions to save to an album.
   /// If you want to save to an album other than the one created by your app
   /// See: [Permissions](https://github.com/natsuk4ze/gal/wiki/Permissions)
-  static Future<bool> requestAccess({bool toAlbum = false}) async =>
+  static Future<bool> requestPermission({bool toAlbum = false}) async =>
       GalPlatform.instance.requestAccess(toAlbum: toAlbum);
 }

--- a/lib/src/gal_exception.dart
+++ b/lib/src/gal_exception.dart
@@ -23,7 +23,7 @@ class GalException implements Exception {
   /// The native code StackTrace is stored in [PlatformException.stacktrace].
   final StackTrace stackTrace;
 
-  factory GalException.fromCode({
+  factory GalException.fromPlatformException({
     required String code,
     required PlatformException platformException,
     required StackTrace stackTrace,

--- a/lib/src/gal_method_channel.dart
+++ b/lib/src/gal_method_channel.dart
@@ -13,7 +13,7 @@ final class MethodChannelGal extends GalPlatform {
     try {
       return await _methodChannel.invokeMethod<T>(method, args);
     } on PlatformException catch (error, stackTrace) {
-      throw GalException.fromCode(
+      throw GalException.fromPlatformException(
         code: error.code,
         platformException: error,
         stackTrace: stackTrace,


### PR DESCRIPTION
This PR implements the breaking changes outlined in issue #210:

- 🎯 Upgrade minimum iOS version from 11.0 to 13.0
- 🤖 Upgrade minimum Android SDK version from 19 to 24
- 🔄 Rename `hasAccess`/`requestAccess` to `hasPermission`/`requestPermission`
- ⚡ Update `GalException.fromCode` to `GalException.fromPlatformException`
- 🛠️ Update CI targets to reflect new minimum versions

## Breaking Changes

This is a major version update that includes breaking changes:

1. **Platform Support**: Dropped support for iOS < 13 and Android < 24
2. **API Changes**: Method names changed for better clarity
3. **Exception Handling**: Factory method renamed for consistency

Closes #210

🤖 Generated with [Claude Code](https://claude.ai/code)