### PR TITLE
Fix putImageBytes producing double file extensions (e.g. photo.jpg.jpg, photo.jpeg.jpg

### DIFF
--- a/android/src/main/java/studio/midoridesign/gal/GalPlugin.java
+++ b/android/src/main/java/studio/midoridesign/gal/GalPlugin.java
@@ -128,10 +128,20 @@ public class GalPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwar
 
     private void putMediaBytes(byte[] bytes, String album, String name)
             throws IOException, SecurityException {
-        ImageFormat imageFormat = Imaging.guessFormat(bytes);
-        String extension = "." + imageFormat.getDefaultExtension().toLowerCase();
+        // If the caller already included an extension in `name` (e.g.
+        // "photo.jpg" or "photo.jpeg"), honor it instead of unconditionally
+        // appending a freshly-guessed one on top -- otherwise the file is
+        // written as "photo.jpg.jpg" / "photo.jpeg.jpg". putMedia() above
+        // already splits an existing extension off file-path-based names;
+        // this brought the bytes-based path in line with that behavior.
+        int dotIndex = name.lastIndexOf('.');
+        String baseName = dotIndex == -1 ? name : name.substring(0, dotIndex);
+        String extension = dotIndex == -1
+                ? "." + Imaging.guessFormat(bytes).getDefaultExtension().toLowerCase()
+                : name.substring(dotIndex);
+
         try (InputStream in = new ByteArrayInputStream(bytes)) {
-            writeData(in, true, name, extension, album);
+            writeData(in, true, baseName, extension, album);
         }
     }
 


### PR DESCRIPTION

<h3>Bug</h3>
<p><code>Gal.putImageBytes()</code> writes files with a duplicated extension on Android — e.g. saving with <code>name: "photo.jpg"</code> produces a gallery file literally named <code>photo.jpg.jpg</code>, and <code>name: "photo.jpeg"</code> produces <code>photo.jpeg.jpg</code>.</p>
<p><strong>Root cause:</strong> in <code>GalPlugin.java</code>, the file-path save path (<code>putMedia</code>, used by <code>Gal.putImage()</code>) correctly separates an existing extension from the given name before writing:</p>
<pre><code class="language-java">private void putMedia(String path, String album, boolean isImage) ... {
    File file = new File(path);
    String name = file.getName();
    int dotIndex = name.lastIndexOf('.');
    if (dotIndex == -1) throw new FileNotFoundException("Extension not found.");
    writeData(in, isImage, name.substring(0, dotIndex), name.substring(dotIndex), album);
}
</code></pre>
<p>But the bytes-based save path (<code>putMediaBytes</code>, used by <code>Gal.putImageBytes()</code>) never did this. It always guessed a fresh extension from the raw image bytes and appended it to the caller's <code>name</code> as-is, regardless of whether <code>name</code> already ended in an extension:</p>
<pre><code class="language-java">private void putMediaBytes(byte[] bytes, String album, String name) ... {
    ImageFormat imageFormat = Imaging.guessFormat(bytes);
    String extension = "." + imageFormat.getDefaultExtension().toLowerCase();
    writeData(in, true, name, extension, album); // name kept whole, extension always appended
}
</code></pre>
<p>Any caller passing a <code>name</code> that already includes an extension (a very natural thing to do — it's how <code>putImage</code>/file-path saving already works) ends up with a duplicated extension in the gallery.</p>
<h3>Fix</h3>
<p>Brought <code>putMediaBytes</code> in line with the existing behavior of <code>putMedia</code>: split off an existing extension from <code>name</code> if present, and only fall back to guessing the extension from the image bytes when <code>name</code> has none.</p>
<pre><code class="language-java">private void putMediaBytes(byte[] bytes, String album, String name)
        throws IOException, SecurityException {
    // If the caller already included an extension in `name` (e.g.
    // "photo.jpg" or "photo.jpeg"), honor it instead of unconditionally
    // appending a freshly-guessed one on top -- otherwise the file is
    // written as "photo.jpg.jpg" / "photo.jpeg.jpg". putMedia() above
    // already splits an existing extension off file-path-based names;
    // this brings the bytes-based path in line with that behavior.
    int dotIndex = name.lastIndexOf('.');
    String baseName = dotIndex == -1 ? name : name.substring(0, dotIndex);
    String extension = dotIndex == -1
            ? "." + Imaging.guessFormat(bytes).getDefaultExtension().toLowerCase()
            : name.substring(dotIndex);

    try (InputStream in = new ByteArrayInputStream(bytes)) {
        writeData(in, true, baseName, extension, album);
    }
}
</code></pre>
<h3>Behavior after fix</h3>

name passed to putImageBytes | Before | After
-- | -- | --
"reduced_123" (no extension) | reduced_123.jpg | reduced_123.jpg (unchanged — still guessed)
"photo.jpg" | photo.jpg.jpg | photo.jpg
"photo.jpeg" | photo.jpeg.jpg | photo.jpeg


<h3>Scope / platforms</h3>
<ul>
<li>Android only (<code>android/src/main/java/studio/midoridesign/gal/GalPlugin.java</code>).</li>
<li>Checked the iOS implementation (<code>GalPlugin.swift</code>) — it passes <code>name</code> straight through to <code>PHAssetCreationRequest.originalFilename</code>, which doesn't exhibit this double-append behavior, so no changes needed there.</li>
<li>No public API changes — <code>Gal.putImageBytes()</code>'s Dart-facing signature and parameters are unaffected.</li>
</ul>
<h3>Testing</h3>
<p>Manually verified against a real device: saved images via <code>Gal.putImageBytes(bytes, name: "&lt;name&gt;.&lt;jpg|jpeg&gt;")</code> and confirmed the resulting Gallery file name no longer duplicates the extension, for both names with and without a pre-existing extension.</p></body></html><!--EndFragment-->
</body>
</html>