### PR TITLE
Fix Windows build on latest MSVC by removing /await flag

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -33,11 +33,6 @@ add_library(${PLUGIN_NAME} SHARED
   ${PLUGIN_SOURCES}
 )
 
-# Added by natsuk4ze for c++ 20
-if(MSVC)
-  target_compile_options(${PLUGIN_NAME} PRIVATE /await)
-endif()
-
 # Apply a standard set of build settings that are configured in the
 # application-level CMakeLists.txt. This can be removed for plugins that want
 # full control over build settings.


### PR DESCRIPTION
## Overview

Fixes #323

Building `gal` on Windows with the latest Visual Studio fails with:

```
error C2338: static assertion failed: 'error STL1011: The /await compiler option,
<experimental/coroutine>, <experimental/generator>, and <experimental/resumable> are
deprecated by Microsoft and will be REMOVED SOON...'
```

## Cause

`windows/CMakeLists.txt` passed the `/await` compiler option to MSVC. `/await` enables
the **legacy experimental coroutine** headers (`<experimental/coroutine>`), which the
latest MSVC has deprecated into a hard error.

The `co_await` / WinRT `IAsyncAction` usage in `gal_plugin.cpp` relies on **C++20**
coroutines (`<coroutine>`), which are already enabled by `set(CMAKE_CXX_STANDARD 20)`.
So `/await` is not only unnecessary but actively harmful on modern toolchains.

## Change

- Removed the `/await` `target_compile_options` block from `windows/CMakeLists.txt`.
- Kept `CMAKE_CXX_STANDARD 20`; WinRT headers automatically select the standard
  `<coroutine>` implementation, so `co_await` keeps working.

This eliminates the dependency on the "REMOVED SOON" experimental headers entirely,
rather than merely silencing the deprecation warning.

## Verification

The existing `ci_windows.yml` runs the example integration tests on `windows-latest`
(current MSVC) across Windows 10 / 11, which exercises the Windows plugin build.
