### PR TITLE
Bump version to 2.3.3

### DIFF
--- a/.github/workflows/ci_ios.yml
+++ b/.github/workflows/ci_ios.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Grant permission
         run: |
           brew tap wix/brew
+          # Homebrew 6.0 requires explicit trust for third-party taps
+          brew trust wix/brew
           brew install applesimutils
           cd example
           applesimutils --booted --bundle studio.midoridesign.galExample --setPermissions photos=YES

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -10,7 +10,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        macos-version: [13, 14, 15]
+        # macOS 13 is excluded because GitHub retired the macos-13 runner image
+        macos-version: [14, 15]
         package_manager: [cocoapods, swiftpm]
       fail-fast: false
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.3
+
+* Fix Windows build on latest MSVC by removing /await flag #324
+
 ## 2.3.2
 
 * Reduce package size by optimizing assets (.pubignore) #296

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gal
 description: Flutter plugin to save images/videos to photos gallery with permission handling
-version: 2.3.2
+version: 2.3.3
 homepage: https://pub.dev/packages/gal
 repository: https://github.com/natsuk4ze/gal
 documentation: https://github.com/natsuk4ze/gal/wiki


### PR DESCRIPTION
## Summary
- Update version from 2.3.2 to 2.3.3 in pubspec.yaml
- Add changelog entry for version 2.3.3
- Fix CI: trust `wix/brew` tap required by Homebrew 6.0 (iOS jobs)
- Fix CI: drop retired `macos-13` runner from the macOS matrix

## Test plan
- [x] Version updated correctly
- [x] Changelog entry added
- [x] Full CI matrix passes